### PR TITLE
Add -funbox-strict-sums, -funbox-small-strict-fields=n, and -funbox-small-strict-sums=n

### DIFF
--- a/compiler/basicTypes/MkId.hs
+++ b/compiler/basicTypes/MkId.hs
@@ -876,7 +876,7 @@ isUnpackableType dflags fam_envs ty
     length cons == 1
         || gopt Opt_UnboxStrictSums dflags
         || unboxSmallStrictSums dflags
-             >= Just (length (unboxedSumRepTypes (map dataConUnboxedSum cons)))
+             >= Just (length (typeUnboxedSumRep cons))
   , all isVanillaDataCon cons
   = all (ok_con_args (unitNameSet (getName tc))) cons
 

--- a/compiler/basicTypes/MkId.hs
+++ b/compiler/basicTypes/MkId.hs
@@ -870,6 +870,9 @@ isUnpackableType dflags fam_envs ty
   | Just (tc, _) <- splitTyConApp_maybe ty
   , -- guess how many constructors prim types have?
     cons@(_ : _) <- tyConDataCons tc
+  , -- If there's more than one constructor, we need the -funbox-strict-sums
+    -- flag in order to unpack it
+    length cons == 1 || gopt Opt_UnboxStrictSums dflags
   , all isVanillaDataCon cons
   = all (ok_con_args (unitNameSet (getName tc))) cons
 

--- a/compiler/main/DynFlags.hs
+++ b/compiler/main/DynFlags.hs
@@ -413,6 +413,7 @@ data GeneralFlag
    | Opt_CaseMerge
    | Opt_UnboxStrictFields
    | Opt_UnboxSmallStrictFields
+   | Opt_UnboxStrictSums
    | Opt_DictsCheap
    | Opt_EnableRewriteRules             -- Apply rewrite rules during simplification
    | Opt_Vectorise
@@ -3066,6 +3067,7 @@ fFlags = [
   flagSpec "write-interface"                  Opt_WriteInterface,
   flagSpec "unbox-small-strict-fields"        Opt_UnboxSmallStrictFields,
   flagSpec "unbox-strict-fields"              Opt_UnboxStrictFields,
+  flagSpec "unbox-strict-sums"                Opt_UnboxStrictSums,
   flagSpec "vectorisation-avoidance"          Opt_VectorisationAvoidance,
   flagSpec "vectorise"                        Opt_Vectorise,
   flagSpec "worker-wrapper"                   Opt_WorkerWrapper,

--- a/compiler/main/DynFlags.hs
+++ b/compiler/main/DynFlags.hs
@@ -413,6 +413,7 @@ data GeneralFlag
    | Opt_DoEtaReduction
    | Opt_CaseMerge
    | Opt_UnboxStrictFields
+   | Opt_UnboxSmallStrictFields
    | Opt_UnboxStrictSums
    | Opt_DictsCheap
    | Opt_EnableRewriteRules             -- Apply rewrite rules during simplification
@@ -879,9 +880,8 @@ data DynFlags = DynFlags {
   initialUnique         :: Int,
   uniqueIncrement       :: Int,
 
-  -- | Max size, in words, of fields that can be unpacked
-  unboxSmallStrictFields :: Maybe Int,
-  unboxSmallStrictSums   :: Maybe Int
+  -- | Max flattened size, in words, of sum types that can be unpacked
+  unboxSmallStrictSums :: Maybe Int
 }
 
 class HasDynFlags m where
@@ -1595,8 +1595,7 @@ defaultDynFlags mySettings =
 
         reverseErrors = False,
 
-        unboxSmallStrictFields = Nothing,
-        unboxSmallStrictSums   = Nothing
+        unboxSmallStrictSums = Nothing
       }
 
 defaultWays :: Settings -> [Way]
@@ -2049,17 +2048,14 @@ showOpt (Option s)  = s
 updOptLevel :: Int -> DynFlags -> DynFlags
 -- ^ Sets the 'DynFlags' to be appropriate to the optimisation level
 updOptLevel n dfs
-  = dfs3{ optLevel = final_n }
+  = dfs2{ optLevel = final_n }
   where
    final_n = max 0 (min 2 n)    -- Clamp to 0 <= n <= 2
    dfs1 = foldr (flip gopt_unset) dfs  remove_gopts
    dfs2 = foldr (flip gopt_set)   dfs1 extra_gopts
-   dfs3 = foldr ($)               dfs2 extra_dflags
 
    extra_gopts  = [ f | (ns,f) <- optLevelFlags, final_n `elem` ns ]
    remove_gopts = [ f | (ns,f) <- optLevelFlags, final_n `notElem` ns ]
-
-   extra_dflags = [ dd | (ns,dd) <- optLevelDynFlags, final_n `elem` ns ]
 
 {- **********************************************************************
 %*                                                                      *
@@ -2682,10 +2678,10 @@ dynamic_flags = [
   , defGhcFlag "dunique-increment"
       (intSuffix (\n d -> d{ uniqueIncrement = n }))
 
-  , defFlag "funbox-small-strict-fields"
-      (optIntSuffix setUnboxSmallStrictFields)
+    -- If the user specifies -funbox-small-strict-sums without an argument,
+    -- use a default size of two words
   , defFlag "funbox-small-strict-sums"
-      (optIntSuffix setUnboxSmallStrictSums)
+      (optIntSuffix (\mi d -> d { unboxSmallStrictSums = mi <|> Just 2 }))
 
         ------ Profiling ----------------------------------------------------
 
@@ -3080,6 +3076,7 @@ fFlags = [
   flagSpec "strictness"                       Opt_Strictness,
   flagSpec "use-rpaths"                       Opt_RPath,
   flagSpec "write-interface"                  Opt_WriteInterface,
+  flagSpec "unbox-small-strict-fields"        Opt_UnboxSmallStrictFields,
   flagSpec "unbox-strict-fields"              Opt_UnboxStrictFields,
   flagSpec "unbox-strict-sums"                Opt_UnboxStrictSums,
   flagSpec "vectorisation-avoidance"          Opt_VectorisationAvoidance,
@@ -3419,7 +3416,7 @@ impliedXFlags
 --  * utils/mkUserGuidePart/Options/
 --  * docs/users_guide/using.rst
 --
--- The first contains the Flag Reference section, which breifly lists all
+-- The first contains the Flag Refrence section, which breifly lists all
 -- available flags. The second contains a detailed description of the
 -- flags. Both places should contain information whether a flag is implied by
 -- -O0, -O or -O2.
@@ -3453,6 +3450,7 @@ optLevelFlags -- see Note [Documenting optimisation flags]
     , ([1,2],   Opt_Specialise)
     , ([1,2],   Opt_CrossModuleSpecialise)
     , ([1,2],   Opt_Strictness)
+    , ([1,2],   Opt_UnboxSmallStrictFields)
     , ([1,2],   Opt_CprAnal)
     , ([1,2],   Opt_WorkerWrapper)
 
@@ -3463,35 +3461,6 @@ optLevelFlags -- see Note [Documenting optimisation flags]
 --  , ([2],     Opt_StaticArgumentTransformation)
 --   Static Argument Transformation needs investigation. See #9374
     ]
-
--- These flags are tricky since (1) they are implied by various optimization
--- settings but (2) they take arguments. Therefore:
---
--- * If the user specifies the flag, use the argument (if no argument was
---   given, use the default value)
--- * If the user does not specify the flag, but the right optimisation level is
---   set, use the default value
-optLevelDynFlags :: [([Int], DynFlags -> DynFlags)]
-optLevelDynFlags -- see Note [Documenting optimisation flags]
-  = [ ([1,2], setUnboxSmallStrictFields Nothing)
-    , ([1,2], setUnboxSmallStrictSums   Nothing)
-    ]
-
--- Default to unboxing fields with a pointer-sized representation
--- (i.e., one word) if given Nothing
-setUnboxSmallStrictFields :: Maybe Int -> DynFlags -> DynFlags
-setUnboxSmallStrictFields mws d =
-    d { unboxSmallStrictFields = mws <|> Just smallFieldSize }
-
--- Default to unboxing sums with a flattened size of at most two words if
--- given Nothing
-setUnboxSmallStrictSums :: Maybe Int -> DynFlags -> DynFlags
-setUnboxSmallStrictSums mws d =
-    d { unboxSmallStrictSums = mws <|> Just smallSumSize }
-
-smallFieldSize, smallSumSize :: Int
-smallFieldSize = 1
-smallSumSize   = 2
 
 -- -----------------------------------------------------------------------------
 -- Standard sets of warning options

--- a/compiler/simplStg/ElimUbxSums.hs
+++ b/compiler/simplStg/ElimUbxSums.hs
@@ -1,16 +1,19 @@
 {-# LANGUAGE CPP, TupleSections #-}
 
 module ElimUbxSums
-  ( unboxedSumTyConFields
+  ( dataConUnboxedSum
+  , unboxedSumTyConFields
   , unboxedSumRepTypes
   ) where
 
 #include "HsVersions.h"
 
+import DataCon
 import Outputable
 import TyCon
 import Type
 import TysPrim
+import TysWiredIn
 import Util
 
 #if __GLASGOW_HASKELL__ < 709
@@ -20,6 +23,11 @@ import Control.Applicative
 import Data.List (partition)
 
 --------------------------------------------------------------------------------
+
+dataConUnboxedSum :: DataCon -> Type
+dataConUnboxedSum dc =
+    let dcrats = dataConRepArgTys dc
+    in mkTyConApp (sumTyCon (length dcrats)) dcrats
 
 -- INVARIANT: Returned list doesn't have unboxed tuples or sums.
 unboxedSumRepTypes :: [Type] -> [Type]


### PR DESCRIPTION
I tested this by compiling the following program:

``` haskell
{-# LANGUAGE BangPatterns #-}
{-# LANGUAGE DeriveGeneric #-}
{-# OPTIONS_GHC -O2 -ddump-deriv #-}
module Example where

import GHC.Generics

data MyEither a b = MyLeft a | MyRight b

data T = MkT !(MyEither Int Int) !(MyEither Int Int)
  deriving Generic
```

with and without `-funbox-strict-sums`, and the output of `-ddump-deriv` confirms that it's `T` is `DecidedStrict` and `DecidedUnpack`, respectively.

Please check that there isn't some other place where unboxed sums can sneak through with `-O2` on.
